### PR TITLE
Add fixes and improvements to work with C++ code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,21 @@ The VMU Profiler was created as a profiling tool for the Grand Theft Auto 3 port
     - User-defined/configurable statistics
 
 ## Usage
-	extern int xform_verts;
 	void update_transformed_verts(vmu_profiler_measurement_t *m)
 	{
-		m->ustorage = (size_t)xform_verts;
+		Engine *engine = (Engine *)m->user_data;
+		m->ustorage = engine->transformed_verts;
 	}
-
-
-	void setup_measures(struct vmu_profiler *p) {
-		vmu_profiler_measurement_t *xv_msr = init_measurement("TVRT", use_unsigned, update_transformed_verts);
-		vmu_profiler_add_measure(p, xv_msr);
-	}
-
 
 	int main(int argc, char* argv[]) {
 		// initialize video
 		// initialize audio
 
-		vmu_profiler_start(<optional configuration>, setup_measures);
+		vmu_profiler *profiler = vmu_profiler_start(<optional configuration>);
+		if (profiler) {
+			vmu_profiler_measurement_t *xv_msr = init_measurement("TVRT", use_unsigned, update_transformed_verts, engine);
+			vmu_profiler_add_measure(p, xv_msr);
+		}
 
 		// Start the game loop
 		while(!done) {

--- a/vmu_profiler.c
+++ b/vmu_profiler.c
@@ -37,6 +37,7 @@ static char pfstr[1024];
 static vmu_profiler_t *profiler_ = NULL;
 
 
+/*
 // sample measure for FPS, depends on internal implementaiton details
 void update_fps(vmu_profiler_measurement_t *m)
 {
@@ -61,7 +62,7 @@ void update_pvr_ram(vmu_profiler_measurement_t *m)
 
 	m->fstorage = pvr_mem;
 }
-
+*/
 
 void vmu_profiler_add_measure(vmu_profiler_t *prof, vmu_profiler_measurement_t *measure)
 {

--- a/vmu_profiler.c
+++ b/vmu_profiler.c
@@ -71,12 +71,15 @@ void vmu_profiler_add_measure(vmu_profiler_t *prof, vmu_profiler_measurement_t *
 }
 
 
-vmu_profiler_measurement_t *init_measurement(char *name, enum measure_type m, void (*callback)(vmu_profiler_measurement_t *m))
+vmu_profiler_measurement_t *init_measurement(const char *name, enum measure_type m, void (*callback)(vmu_profiler_measurement_t *m), void *user_data)
 {
 	vmu_profiler_measurement_t *measure = (vmu_profiler_measurement_t *)malloc(sizeof(vmu_profiler_measurement_t));
 
 	measure->disp_name = name;
 	measure->m = m;
+	measure->user_data = user_data;
+	measure->ustorage = 0;
+	measure->sstorage[0] = 0;
 	measure->generate_value = callback;
 
 	return measure;
@@ -152,8 +155,7 @@ static void *vmu_profiler_run_(void *arg)
 	return (void *)success;
 }
 
-
-int vmu_profiler_start(const vmu_profiler_config_t *config, void (*setup_func)(struct vmu_profiler *p))
+vmu_profiler_t *vmu_profiler_start(const vmu_profiler_config_t *config)
 {
 	static const vmu_profiler_config_t default_config = {
 		.thread_priority = VMU_PROFILER_THREAD_PRIO_DEFAULT_,
@@ -161,12 +163,10 @@ int vmu_profiler_start(const vmu_profiler_config_t *config, void (*setup_func)(s
 		.fps_avg_frames = VMU_PROFILER_FPS_AVG_FRAMES_DEFAULT_,
 		.maple_port = VMU_PROFILER_MAPLE_PORT_DEFAULT_};
 
-	int success = true;
 	vmu_profiler_t *profiler = NULL;
 
 	if (vmu_profiler_running()) {
 		fprintf(stderr, "vmu_profiler_start(): Profiler already running!\n");
-		success = false;
 		goto done;
 	} else {
 		fprintf(stderr, "vmu_profiler_start(): Launching profiler thread.\n");
@@ -178,7 +178,6 @@ int vmu_profiler_start(const vmu_profiler_config_t *config, void (*setup_func)(s
 	profiler = malloc(sizeof(vmu_profiler_t) + sizeof(float) * fps_frames);
 	if (!profiler) {
 		fprintf(stderr, "\tVMU Profiler failed to allocate!\n");
-		success = false;
 		goto done;
 	}
 
@@ -202,7 +201,6 @@ int vmu_profiler_start(const vmu_profiler_config_t *config, void (*setup_func)(s
 
 	if (rwsem_init(&profiler->rwsem) < 0) {
 		fprintf(stderr, "\tCould not initialize RW semaphore!");
-		success = false;
 		goto dealloc;
 	}
 
@@ -213,15 +211,12 @@ int vmu_profiler_start(const vmu_profiler_config_t *config, void (*setup_func)(s
 		.label = VMU_PROFILER_THD_LABEL_,
 	};
 
-	(*setup_func)(profiler);
-
 	profiler->done = 0;
 
 	profiler->thread = thd_create_ex(&attr, vmu_profiler_run_, profiler);
 
 	if (!profiler->thread) {
 		fprintf(stderr, "\tFailed to spawn profiler thread!\n");
-		success = false;
 		goto deinit_sem;
 	}
 
@@ -237,9 +232,8 @@ dealloc:
 	profiler = NULL;
 
 done:
-	return success;
+	return profiler_;
 }
-
 
 int vmu_profiler_stop(void)
 {
@@ -303,17 +297,11 @@ int vmu_profiler_update(void)
 		return false;
 	}
 
-	pvr_stats_t pvr_stats;
-	pvr_get_stats(&pvr_stats);
-
-	profiler_->fps_frames[profiler_->fps_frame++] = pvr_stats.frame_rate;
-
-	if (profiler_->fps_frame >= profiler_->config.fps_avg_frames)
-		profiler_->fps_frame = 0;
-
 	for (int i = 0; i < profiler_->measure_count; i++) {
 		vmu_profiler_measurement_t *measure = profiler_->measures[i];
-		(*measure->generate_value)(measure);
+		if (measure->generate_value) {
+			measure->generate_value(measure);
+		}
 	}
 
 	if (rwsem_write_unlock(&profiler_->rwsem) < 0) {

--- a/vmu_profiler.h
+++ b/vmu_profiler.h
@@ -16,7 +16,11 @@
             // initialize video
             // initialize audio
 
-            vmu_profiler_start(<optional configuration>);
+            vmu_profiler *profiler = vmu_profiler_start(<optional configuration>);
+            if (profiler) {
+                // Add some measurements
+                vmu_profiler_add_measure(profiler, init_measurement("FPS", use_float, update_fps, NULL));
+            }
 
             // Start the game loop
             while(!done) {
@@ -47,6 +51,13 @@ extern "C" {
 #include <kos.h>
 #include <stdbool.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+#include <atomic>
+using atomic_bool = std::atomic<bool>;
+#else
+#include <stdatomic.h>
+#endif
 
 #define VMU_PROFILER_MAX_MEASURES   5
 
@@ -79,8 +90,9 @@ enum measure_type {
 
 typedef struct vmu_profiler_measurement {
     // 4 chars or less
-    char *disp_name;
+    const char *disp_name;
     enum measure_type m;
+    void *user_data;
     //
     union {
         float fstorage;
@@ -101,17 +113,14 @@ typedef struct vmu_profiler
 
     int measure_count;
     struct vmu_profiler_measurement *measures[VMU_PROFILER_MAX_MEASURES];
-
-    unsigned fps_frame;
-    float fps_frames[];
 } vmu_profiler_t;
 
-int vmu_profiler_start(const vmu_profiler_config_t *config, void (*setup_func)(struct vmu_profiler *p));
+vmu_profiler_t *vmu_profiler_start(const vmu_profiler_config_t *config);
 int vmu_profiler_stop(void);
 int vmu_profiler_update(void);
 int vmu_profiler_running(void);
 
-vmu_profiler_measurement_t *init_measurement(char *name, enum measure_type m, void (*callback)(vmu_profiler_measurement_t *m));
+vmu_profiler_measurement_t *init_measurement(const char *name, enum measure_type m, void (*callback)(vmu_profiler_measurement_t *m), void *user_data);
 void vmu_profiler_add_measure(vmu_profiler_t *prof, vmu_profiler_measurement_t *measure);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Hi @gyrovorbis, initially I wanted to add only one fix related `atomic_bool` variable declaration that generates compilation error when you compiles library under C++. However, I found it's kind of uncomfortable to use with necessity to use `setup_func` in start function. So, here are several fixes I made for this wonderful lib

- Fixed compilation error for `atomic_bool` under C++
- Removed `setup_func` from vmu_profiler_start function and instead I return pointer to vmu_profiler_t in this function
- I added `user_data` to vmu_profiler_measurement so that you can get pointer to needed object inside of get_measure_callbacxk
- I also removed `fps_frame` and `fps_frames[]` variables from vmu_profiler_t and code that used them in vmu_profiler_update, since I think this should be made on client side

My changes brake backward compatibility but I believe it's not a big deal. Here is an example how I use this new format in my code

    ```
    vmu_profiler *profiler = vmu_profiler_start(&vmu_config);
    if (profiler) {
        auto fps_callback = +[](vmu_profiler_measurement_t *m) {
            Engine* engine = static_cast<Engine*>(m->user_data);
            if (!engine) {
                return;
            }

            m->fstorage = engine->GetRenderContext()->GetFPS();
        };

        vmu_profiler_add_measure(profiler, init_measurement(" FPS", use_float, fps_callback, this));
    }
```

